### PR TITLE
Misc fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-droidcam*
+/droidcam
+/droidcam-cli
 
 # vim swap files
 *.swp

--- a/Makefile
+++ b/Makefile
@@ -6,26 +6,20 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 # Use at your own risk. See README file for more details.
 
-#
 # Variables with ?= can be changed during invocation
 # Example:
 #  APPINDICATOR=ayatana-appindicator3-0.1 make droidcam
 
 APPINDICATOR ?= appindicator3-0.1
-JPEG_DIR     ?= /opt/libjpeg-turbo
-JPEG_INCLUDE ?= $(JPEG_DIR)/include
-JPEG_LIB     ?= $(JPEG_DIR)/lib`getconf LONG_BIT`
+CFLAGS ?= -Wall -O2
 
-
-CC   = gcc
-CFLAGS = -Wall -O2
 GTK   = `pkg-config --libs --cflags gtk+-3.0` `pkg-config --libs x11`
 GTK  += `pkg-config --libs --cflags $(APPINDICATOR)`
 LIBAV = `pkg-config --libs --cflags libswscale libavutil`
-LIBS  =  -lspeex -lasound -lpthread -lm
-JPEG  = -I$(JPEG_INCLUDE) $(JPEG_LIB)/libturbojpeg.a
+LIBS  = -lspeex -lasound -lpthread -lm
+JPEG  = `pkg-config --libs --cflags libturbojpeg`
 SRC   = src/connection.c src/settings.c src/decoder*.c src/av.c src/usb.c src/queue.c
-USBMUXD = -lusbmuxd
+USBMUXD = `pkg-config --libs --cflags libusbmuxd-2.0`
 
 ifneq ($(findstring ayatana,$(APPINDICATOR)),)
 	CFLAGS += -DUSE_AYATANA_APPINDICATOR

--- a/src/av.c
+++ b/src/av.c
@@ -12,6 +12,8 @@
 #include "decoder.h"
 #include <stdatomic.h>
 #include <stdint.h>
+#include <string.h>
+#include <sys/socket.h>
 
 extern atomic_bool a_running;
 extern atomic_bool v_running;
@@ -37,52 +39,76 @@ SOCKET GetConnection(void) {
 // Battry Check thread
 void *BatteryThreadProc(__attribute__((__unused__)) void *args) {
     SOCKET socket = INVALID_SOCKET;
-    char buf[128];
-    char battery_value[32];
-    int i, j;
+    char buf[96];
+    char battery_value[5];
+    struct timeval tv = {0};
+    tv.tv_sec = 1;
 
-    memset(battery_value, 0, sizeof(battery_value));
     dbgprint("Battery Thread Start\n");
 
     usleep(500000);
     while (v_running || a_running) {
+        uint8_t battery_value_pos = 0;
+        size_t percent_len = 0;
+
         socket = GetConnection();
         if (socket == INVALID_SOCKET) {
             goto LOOP;
         }
 
-        if (Send(BATTERY_REQ, CSTR_LEN(BATTERY_REQ), socket) <= 0) {
+        if (setsockopt(socket, SOL_SOCKET, SO_RCVTIMEO, (const char *)&tv,
+                       sizeof(tv)) == -1) {
+            goto LOOP;
+        };
+
+        if (!Send(BATTERY_REQ, CSTR_LEN(BATTERY_REQ), socket)) {
             errprint("error sending battery status request\n");
             goto LOOP;
         }
 
         memset(buf, 0, sizeof(buf));
-        if (Recv(buf, sizeof(buf), socket) <= 0) {
+        memset(battery_value, 0, sizeof(battery_value));
+        if (RecvAll(buf, sizeof(buf), socket) <= 0) {
             goto LOOP;
         }
 
-        for (i = 0; i < (sizeof(buf)-4); i++) {
-            if (buf[i] == '\r' && buf[i+1] == '\n' && buf[i+2] == '\r' && buf[i+3] == '\n') {
-                    i += 4;
-                    break;
+        for (uint8_t i = 0; i < (sizeof(buf) - 4); i += 4) {
+            char *tmp = memchr(&buf[i], '\r', sizeof(buf));
+            if (!tmp) {
+                goto LOOP;
+            }
+            if (memcmp(tmp + 1, "\n\r\n", 3) == 0) {
+                battery_value_pos = (tmp - buf) + 4;
+                break;
+            }
+        }
+        if (!battery_value_pos || battery_value_pos > (sizeof(buf) - (4 + 1)) ||
+            buf[battery_value_pos] == '0') {
+            goto LOOP;
+        }
+
+        for (uint8_t j = 0; j < 3; j++) {
+            if (buf[battery_value_pos + j] >= '0' &&
+                buf[battery_value_pos + j] <= '9') {
+                battery_value[j] = buf[battery_value_pos + j];
+                percent_len++;
+            } else {
+                break;
             }
         }
 
-        j = 0;
-        while (i < sizeof(buf) && j < (sizeof(battery_value)-2) && buf[i] >= '0' && buf[i] <= '9')
-                battery_value[j++] = buf[i++];
+        if (percent_len == 0) {
+            battery_value[0] = '-';
+            percent_len = 1;
+        }
 
-        if (j == 0)
-            battery_value[j++] = '-';
-
-        battery_value[j++] = '%';
-        battery_value[sizeof(battery_value) - 1] = 0;
+        battery_value[percent_len] = '%';
         dbgprint("battery_value: %s\n", battery_value);
         UpdateBatteryLabel(battery_value);
 
     LOOP:
         disconnect(socket);
-        for (j = 0; j < 30000 && (v_running || a_running); j++)
+        for (uint16_t i = 0; i < 30000 && (v_running || a_running); i++)
             usleep(1000);
     }
 
@@ -120,7 +146,7 @@ server_wait:
     }
 
     len = snprintf(buf, sizeof(buf), VIDEO_REQ, decoder_get_video_width(), decoder_get_video_height());
-    if (Send(buf, len, videoSocket) <= 0){
+    if (!Send(buf, len, videoSocket)){
         MSG_ERROR("Error sending request, DroidCam might be busy with another client.");
         goto early_out;
     }
@@ -229,7 +255,7 @@ TCP_ONLY:
         return 0;
     }
 
-    if (Send(AUDIO_REQ, CSTR_LEN(AUDIO_REQ), socket) <= 0) {
+    if (!Send(AUDIO_REQ, CSTR_LEN(AUDIO_REQ), socket)) {
         MSG_ERROR("Error sending audio request");
         goto early_out;
     }

--- a/src/connection.c
+++ b/src/connection.c
@@ -9,6 +9,8 @@
 #include <arpa/inet.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <stdatomic.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/select.h>
@@ -20,14 +22,14 @@
 #include "connection.h"
 
 SOCKET wifiServerSocket = INVALID_SOCKET;
-extern int v_running;
+extern atomic_bool v_running;
 
-char* DROIDCAM_CONNECT_ERROR = \
+const char* DROIDCAM_CONNECT_ERROR = \
     "Connect failed, please try again.\n"
     "Check IP and Port.\n"
     "Check network connection.\n";
 
-SOCKET Connect(const char* ip, int port, char **errormsg) {
+SOCKET Connect(const char* ip, int port, const char **errormsg) {
     int flags;
     struct sockaddr_in sin;
     SOCKET sock = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);

--- a/src/connection.c
+++ b/src/connection.c
@@ -85,41 +85,41 @@ _error_out:
     return sock;
 }
 
-int Send(const char * buffer, int bytes, SOCKET s) {
+bool Send(const char * buffer, int bytes, SOCKET s) {
     ssize_t w = 0;
     char *ptr = (char*) buffer;
     while (bytes > 0) {
         w = send(s, ptr, bytes, 0);
         if (w <= 0) {
-            return -1;
+            return false;
         }
         bytes -= w;
         ptr += w;
     }
-    return 1;
+    return true;
 }
 
-int Recv(const char* buffer, int bytes, SOCKET s) {
+ssize_t Recv(const char* buffer, int bytes, SOCKET s) {
     return recv(s, (char*)buffer, bytes, 0);
 }
 
-int RecvAll(const char* buffer, int bytes, SOCKET s) {
+ssize_t RecvAll(const char* buffer, int bytes, SOCKET s) {
     return recv(s, (char*)buffer, bytes, MSG_WAITALL);
 }
 
-int RecvNonBlock(char * buffer, int bytes, SOCKET s) {
+ssize_t RecvNonBlock(char * buffer, int bytes, SOCKET s) {
     int res = recv(s, buffer, bytes, MSG_DONTWAIT);
     return (res < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) ? 0 : res;
 }
 
-int RecvNonBlockUDP(char * buffer, int bytes, SOCKET s) {
+ssize_t RecvNonBlockUDP(char * buffer, int bytes, SOCKET s) {
     struct sockaddr_in from;
     socklen_t fromLen = sizeof(from);
     int res = recvfrom(s, buffer, bytes, MSG_DONTWAIT, (struct sockaddr *)&from, &fromLen);
     return (res < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) ? 0 : res;
 }
 
-int SendUDPMessage(SOCKET s, const char *message, int length, char *ip, int port) {
+ssize_t SendUDPMessage(SOCKET s, const char *message, int length, char *ip, int port) {
     struct sockaddr_in sin;
     sin.sin_port = htons((uint16_t)port);
     sin.sin_family = AF_INET;

--- a/src/connection.h
+++ b/src/connection.h
@@ -13,7 +13,7 @@
 typedef int SOCKET;
 typedef long int SOCKET_PTR;
 
-SOCKET Connect(const char* ip, int port, char **errormsg);
+SOCKET Connect(const char* ip, int port, const char **errormsg);
 void connection_cleanup();
 void disconnect(SOCKET s);
 

--- a/src/connection.h
+++ b/src/connection.h
@@ -9,6 +9,9 @@
 #ifndef __CONN_H__
 #define __CONN_H__
 
+#include <stdbool.h>
+#include <sys/types.h>
+
 #define INVALID_SOCKET -1
 typedef int SOCKET;
 typedef long int SOCKET_PTR;
@@ -19,11 +22,11 @@ void disconnect(SOCKET s);
 
 SOCKET accept_connection(int port);
 SOCKET CreateUdpSocket(void);
-int Send(const char * buffer, int bytes, SOCKET s);
-int Recv(const char * buffer, int bytes, SOCKET s);
-int RecvAll(const char * buffer, int bytes, SOCKET s);
-int RecvNonBlock(char * buffer, int bytes, SOCKET s);
-int RecvNonBlockUDP(char * buffer, int bytes, SOCKET s);
-int SendUDPMessage(SOCKET s, const char *message, int length, char *ip, int port);
+bool Send(const char * buffer, int bytes, SOCKET s);
+ssize_t Recv(const char * buffer, int bytes, SOCKET s);
+ssize_t RecvAll(const char * buffer, int bytes, SOCKET s);
+ssize_t RecvNonBlock(char * buffer, int bytes, SOCKET s);
+ssize_t RecvNonBlockUDP(char * buffer, int bytes, SOCKET s);
+ssize_t SendUDPMessage(SOCKET s, const char *message, int length, char *ip, int port);
 
 #endif

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -93,10 +93,10 @@ int decoder_init(const char* v4l2_device, unsigned v4l2_width, unsigned v4l2_hei
         set_v4l2_device(v4l2_device);
         droidcam_device_fd = open_v4l2_device();
     } else {
-        droidcam_device_fd = find_v4l2_device("platform:v4l2loopback_dc");
+        droidcam_device_fd = find_v4l2_device("platform:v4l2loopback_dc", &WEBCAM_W, &WEBCAM_H);
         if (droidcam_device_fd < 0) {
             // check for generic v4l2loopback device
-            droidcam_device_fd = find_v4l2_device("platform:v4l2loopback");
+            droidcam_device_fd = find_v4l2_device("platform:v4l2loopback", &WEBCAM_W, &WEBCAM_H);
         }
     }
 
@@ -108,13 +108,6 @@ int decoder_init(const char* v4l2_device, unsigned v4l2_width, unsigned v4l2_hei
         WEBCAM_W = 320;
         WEBCAM_H = 240;
         droidcam_device_fd = 0;
-    } else {
-        query_v4l_device(droidcam_device_fd, &WEBCAM_W, &WEBCAM_H);
-        dbgprint("WEBCAM_W=%d, WEBCAM_H=%d\n", WEBCAM_W, WEBCAM_H);
-        if (WEBCAM_W < 2 || WEBCAM_H < 2 || WEBCAM_W > 9999 || WEBCAM_H > 9999){
-            MSG_ERROR("Unable to query v4l2 device for correct parameters");
-            return 0;
-        }
     }
 
     memset(&jpg_decoder, 0, sizeof(struct jpg_dec_ctx_s));

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -47,7 +47,7 @@ int decoder_horizontal_flip();
 int decoder_vertical_flip();
 void decoder_show_test_image();
 
-/* 20ms 16hkz 16 bit */
+/* 20ms 16khz 16 bit */
 #define DROIDCAM_CHUNK_MS_2           20
 #define DROIDCAM_SPX_CHUNK_BYTES_2    70
 #define DROIDCAM_PCM_CHUNK_BYTES_2    640
@@ -65,7 +65,7 @@ void decoder_show_test_image();
 
 void set_v4l2_device(const char* device);
 int open_v4l2_device(void);
-int find_v4l2_device(const char* bus_info);
+int find_v4l2_device(const char* bus_info, unsigned *in_v4l2_width, unsigned *in_v4l2_height);
 void query_v4l_device(int droidcam_device_fd, unsigned *WEBCAM_W, unsigned *WEBCAM_H);
 
 snd_pcm_t *find_snd_device(void);

--- a/src/decoder_snd.c
+++ b/src/decoder_snd.c
@@ -24,14 +24,12 @@ static snd_pcm_sframes_t period_size;
 static unsigned int period_time = PERIOD_TIME;/* period time in us */
 static unsigned int buffer_time = DROIDCAM_SPEEX_BACKBUF_MAX_COUNT * PERIOD_TIME; /* ring buffer length in us */
 
-snd_pcm_hw_params_t *hwparams;
-snd_pcm_sw_params_t *swparams;
-
 static int set_hwparams(snd_pcm_t *handle, snd_pcm_hw_params_t *params, snd_pcm_access_t access) {
     unsigned int rrate;
     snd_pcm_uframes_t size;
-    int err, dir;
-    int resample = 1;
+    int err;
+    int dir = 0;
+    const unsigned int resample = 1;
     /* choose all parameters */
     err = snd_pcm_hw_params_any(handle, params);
     if (err < 0) {
@@ -248,6 +246,9 @@ int snd_transfer_commit(snd_pcm_t *handle, struct snd_transfer_s *transfer) {
 snd_pcm_t *find_snd_device(void) {
     int err, card, i;
     snd_pcm_t *handle = NULL;
+    snd_pcm_hw_params_t *hwparams;
+    snd_pcm_sw_params_t *swparams;
+
     snd_pcm_hw_params_alloca(&hwparams);
     snd_pcm_sw_params_alloca(&swparams);
 

--- a/src/droidcam-cli.c
+++ b/src/droidcam-cli.c
@@ -8,6 +8,8 @@
 
 #include <pthread.h>
 #include <signal.h>
+#include <stdatomic.h>
+#include <stdbool.h>
 
 #include "common.h"
 #include "settings.h"
@@ -23,9 +25,9 @@ Thread athread = {0, -1}, vthread = {0, -1}, dthread = {0, -1};
 
 char *v4l2_dev = 0;
 unsigned v4l2_width = 0, v4l2_height = 0;
-int v_running = 0;
-int a_running = 0;
-int thread_cmd = 0;
+atomic_bool a_running = false;
+atomic_bool v_running = false;
+char thread_cmd = 0;
 int no_controls = 0;
 struct settings g_settings = {0};
 
@@ -37,8 +39,8 @@ void * VideoThreadProc(void * args);
 void * DecodeThreadProc(void * args);
 
 void sig_handler(__attribute__((__unused__)) int sig) {
-    a_running = 0;
-    v_running = 0;
+    a_running = false;
+    v_running = false;
     return;
 }
 
@@ -111,7 +113,7 @@ static void parse_args(int argc, char *argv[]) {
                 continue;
             }
             if (argv[i][0] == '-' && argv[i][1] == 'v') {
-                v_running = 1;
+                v_running = true;
                 continue;
             }
 
@@ -140,8 +142,8 @@ static void parse_args(int argc, char *argv[]) {
         if (argv[i][0] == '-' && argv[i][1] == 'l') {
             g_settings.port = strtoul(argv[i+1], NULL, 10);
             g_settings.connection = CB_WIFI_SRVR;
-            a_running = 0;
-            v_running = 1;
+            a_running = false;
+            v_running = true;
             return;
         }
 
@@ -233,7 +235,7 @@ int main(int argc, char *argv[]) {
     parse_args(argc, argv);
 
     if (!v_running && !a_running)
-        v_running = 1;
+        v_running = true;
 
     if (!decoder_init(v4l2_dev, v4l2_width, v4l2_height)) {
         return 2;
@@ -262,7 +264,7 @@ int main(int argc, char *argv[]) {
                 videoSocket = rc;
             }
             else {
-                char *errmsg = NULL;
+                const char *errmsg = NULL;
                 videoSocket = Connect(g_settings.ip, g_settings.port, &errmsg);
                 if (videoSocket == INVALID_SOCKET) {
                     errprint("Video: Connect failed to %s:%d\n", g_settings.ip, g_settings.port);

--- a/src/droidcam.c
+++ b/src/droidcam.c
@@ -105,7 +105,7 @@ void UpdateBatteryLabel(char *battery_value)  {
 	gtk_label_set_text(GTK_LABEL(batteryText), battery_value);
 }
 
-static void Stop(void) {
+static void stop_av(void) {
 	a_running = false;
 	v_running = false;
 	dbgprint("join\n");
@@ -125,7 +125,9 @@ static void Stop(void) {
 		g_thread_join(hBatteryThread);
 		hBatteryThread = NULL;
 	}
+}
 
+static void reset_ui(void) {
 	gtk_widget_set_sensitive(GTK_WIDGET(elButton), FALSE);
 	gtk_widget_set_sensitive(GTK_WIDGET(wbButton), FALSE);
 	gtk_widget_set_sensitive(GTK_WIDGET(menuButton), FALSE);
@@ -255,7 +257,8 @@ _up:
 	switch (cb) {
 		case CB_BUTTON:
 			if (v_running || a_running) {
-				Stop();
+				reset_ui();
+				stop_av();
 				cb = (int)g_settings.connection;
 				goto _up;
 			}
@@ -664,7 +667,7 @@ int main(int argc, char *argv[])
 	g_signal_connect(window, "delete-event", G_CALLBACK(delete_window_callback), window);
 	gtk_widget_show_all(window);
 
-	Stop(); // reset the UI
+	reset_ui();
 	LoadSettings(&g_settings);
 	if (argc >= 1) {
 		parse_args(argc, argv);
@@ -711,7 +714,7 @@ int main(int argc, char *argv[])
 
 		// main loop
 		gtk_main();
-		Stop();
+		stop_av();
 		decoder_fini();
 		connection_cleanup();
 		SaveSettings(&g_settings);

--- a/v4l2loopback/test.c
+++ b/v4l2loopback/test.c
@@ -112,7 +112,7 @@ int main(int argc, char**argv)
         printf("using output device: %s\n", video_device);
     }
 
-    fdwr = open(video_device, O_RDWR);
+    fdwr = open(video_device, O_WRONLY);
     assert(fdwr >= 0);
 
     ret_code = ioctl(fdwr, VIDIOC_QUERYCAP, &vid_caps);


### PR DESCRIPTION
Original: `https://github.com/dev47apps/droidcam/pull/231`
1. Automatically detect libturbojpeg linking arguments.
2. Fixed a data race with `a_running` and `v_running` when exiting.
3. Automatically try next v4l2 dev when failing to set pixel format.
4. Not reset gtk widgets when gtk main loop has stopped.
5. Wait until battery level info is received (currently always 1s),
because level info is actually sent later so mostly `recv`
returns before the client sends.